### PR TITLE
Fix login redirects to existing dashboards

### DIFF
--- a/login.html
+++ b/login.html
@@ -50,13 +50,13 @@
 
         switch (match.rol) {
           case "admin":
-            window.location.href = "admin.html";
+            window.location.href = "dashboard-admin.html";
             break;
           case "abogado":
-            window.location.href = "abogado.html";
+            window.location.href = "dashboard-abogado.html";
             break;
           default:
-            window.location.href = "dashboard-cliente.html";
+            window.location.href = "index.html";
         }
       } else {
         alert("Credenciales incorrectas.");


### PR DESCRIPTION
## Summary
- Correct login redirection for admin and lawyer roles to existing dashboard pages
- Default to home page when user role is not admin or lawyer

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689606d72de483268fd74a74dfc0c108