### PR TITLE
Aislar cierre de popup lateral

### DIFF
--- a/assets/js/styles_VE.js
+++ b/assets/js/styles_VE.js
@@ -111,6 +111,7 @@ scrollTopBtn.addEventListener("click", (e) => {
 const services = document.querySelectorAll('.service-item');
 const popup = document.getElementById('popup-lateral');
 const servicesSection = document.querySelector('.services-section');
+const popupCloseLateral = document.querySelector('.popup-close-lateral');
 
 services.forEach(service => {
   service.addEventListener('click', () => {
@@ -127,8 +128,8 @@ services.forEach(service => {
   });
 });
 
-// Cerrar el popup
-popupClose.addEventListener('click', () => {
+// Cerrar el popup lateral al hacer clic en el botón de cierre (.popup-close-lateral)
+popupCloseLateral.addEventListener('click', () => {
   popup.classList.remove('active');
   servicesSection.classList.remove('move-left');
 });


### PR DESCRIPTION
## Summary
- Añade `popupCloseLateral` para apuntar al botón `.popup-close-lateral` y manejar el cierre del popup lateral.
- Actualiza el listener y el comentario para que se refieran explícitamente al botón lateral.

## Testing
- `node test_popups.js` (ambos popups se cerraron correctamente en entorno simulado).

------
https://chatgpt.com/codex/tasks/task_e_68960a7214708326a65c14d617b96849