### PR TITLE
Actualizar enlace de seguridad

### DIFF
--- a/assets/js/styles_VE.js
+++ b/assets/js/styles_VE.js
@@ -16,10 +16,14 @@ const popupBody     = document.querySelector('.popup-body'),
     closeButton   = modal.querySelector('.close');
 
 
-// Añadir evento de clic al botón de política de seguridad
-document.getElementById("menu_politica_seguridad").addEventListener("click", function () {
-  window.location.href = "politica_seguridad.html";
-});
+// Añadir evento de clic al botón de política de seguridad si existe
+const menuPoliticaSeguridad = document.getElementById("menu_politica_seguridad");
+if (menuPoliticaSeguridad) {
+  menuPoliticaSeguridad.addEventListener("click", function (event) {
+    event.preventDefault();
+    window.location.href = "politica_seguridad.html";
+  });
+}
 
 // Añadir evento de clic a cada elemento about-item
 aboutItems.forEach(item => {

--- a/formulario-contacto.html
+++ b/formulario-contacto.html
@@ -13,7 +13,7 @@
             <li><a href="index.html#home"><i class="fas fa-home"></i> Inicio</a></li>
             <li><a href="index.html#about"><i class="fas fa-users"></i> Nosotros</a></li>
             <li><a href="index.html#services"><i class="fas fa-briefcase"></i> Servicios</a></li>
-            <li><a href="politica_seguridad.html"><i class="fas fa-shield-alt"></i> Seguridad y Privacidad</a></li>
+            <li><a href="#" id="menu_politica_seguridad"><i class="fas fa-shield-alt"></i> Seguridad y Privacidad</a></li>
         </ul>
     </nav>
     <!-- Sección principal con el formulario -->
@@ -55,6 +55,14 @@
     <script>
         const form = document.getElementById("contactForm");
         const mainContent = document.getElementById("main-content");
+        const menuPoliticaSeguridad = document.getElementById("menu_politica_seguridad");
+
+        if (menuPoliticaSeguridad) {
+            menuPoliticaSeguridad.addEventListener("click", function (event) {
+                event.preventDefault();
+                window.location.href = "politica_seguridad.html";
+            });
+        }
 
         form.addEventListener("submit", function (event) {
             event.preventDefault(); // Evita el envío normal del formulario

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
             <li><a href="#home">Inicio</a></li>
             <li><a href="#about">Nosotros</a></li>
             <li><a href="#services">Servicios</a></li>
-            <li id="menu_politica_seguridad"><a href="#seguridad">Seguridad</a></li>
+            <li><a href="#" id="menu_politica_seguridad">Seguridad</a></li>
             <li class="submenu">
               <a href="#">Contacto</a>
               <ul class="submenu-options">


### PR DESCRIPTION
## Summary
- Manejar desde JavaScript la redirección de la opción "Seguridad" evitando enlaces directos en HTML
- Añadir control preventDefault al evento de menú para mejorar la navegación
- Habilitar el mismo comportamiento en el formulario de contacto

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68962a872dd8832686fdbf10722723ee