### PR TITLE
docs: add server startup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# WebAbogados
+
+## Inicio rápido
+
+1. Instala las dependencias:
+   ```bash
+   npm install
+   ```
+2. Inicia el servidor con Node:
+   ```bash
+   node server.js
+   ```
+   o utilizando el script de npm:
+   ```bash
+   npm start
+   ```
+
+Una vez iniciado, abre [http://localhost:3000](http://localhost:3000) en tu navegador para ver la aplicación. El servidor Express incluido en este repositorio es suficiente; no se necesita ningún otro servidor adicional.
+
+## Detalles
+
+El servidor se ejecuta por defecto en el puerto `3000`. Puedes cambiarlo estableciendo la variable de entorno `PORT` antes de iniciar la aplicación.


### PR DESCRIPTION
## Summary
- add README with instructions to install dependencies, start the server and access http://localhost:3000

## Testing
- `npm install` *(fails: Merge conflict in package.json)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_689b83c8990883268431ea6cde3598e0