### PR TITLE
Redirect missing static files to index

### DIFF
--- a/server.js
+++ b/server.js
@@ -73,6 +73,21 @@ app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'index.html'));
 });
 
+// Fallback para archivos estáticos inexistentes
+app.use((req, res, next) => {
+  const ext = path.extname(req.path).toLowerCase();
+  const known = ['.html', '.css', '.js', '.png', '.jpg', '.jpeg', '.gif', '.svg', '.ico'];
+  if (ext && known.includes(ext)) {
+    return res.redirect('/index.html');
+  }
+  next();
+});
+
+// 404 para rutas claramente inexistentes
+app.use((req, res) => {
+  res.status(404).send('404 Not Found');
+});
+
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
   console.log(`Servidor escuchando en puerto ${PORT}`);


### PR DESCRIPTION
## Summary
- Redirect missing static asset requests to `index.html`
- Keep 404 responses for requests with unknown extensions

## Testing
- `npm test` *(fails: EJSONPARSE invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b8543bcf08326ba5a8447af21c5e4