### PR TITLE
Use extensionless routes in navigation

### DIFF
--- a/assets/js/abogado.js
+++ b/assets/js/abogado.js
@@ -1,12 +1,12 @@
 function cerrarSesion() {
   localStorage.removeItem("usuario");
-  window.location.href = "index.html";
+  window.location.href = "/";
 }
 
 const usuario = JSON.parse(localStorage.getItem("usuario"));
 if (!usuario || usuario.rol !== "abogado") {
   alert("Acceso no autorizado");
-  window.location.href = "login.html";
+  window.location.href = "/login";
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/assets/js/acceso.js
+++ b/assets/js/acceso.js
@@ -1,5 +1,5 @@
 const usuario = JSON.parse(localStorage.getItem("usuario"));
 if (!usuario) {
   alert("Debes iniciar sesión para acceder a esta sección.");
-  window.location.href = "login.html";
+  window.location.href = "/login";
 }

--- a/assets/js/formulario-contacto.js
+++ b/assets/js/formulario-contacto.js
@@ -6,7 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (menuPoliticaSeguridad) {
     menuPoliticaSeguridad.addEventListener('click', function (event) {
       event.preventDefault();
-      window.location.href = 'politica_seguridad.html';
+      window.location.href = '/politica_seguridad';
     });
   }
 
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
 Nuestro equipo de abogados ya está revisando tu solicitud. En breve nos pondremos en contacto contigo para brindarte más detalles y orientarte sobre los próximos pasos relacionados con tu caso.
 
 Si tienes alguna otra consulta mientras tanto, no dudes en escribirnos nuevamente..</p>
-                    <a href="index.html" class="button">Volver al Inicio</a>
+                    <a href="/" class="button">Volver al Inicio</a>
                 </section>
             `;
   });

--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -16,13 +16,13 @@ async function login(event) {
     localStorage.setItem('token', data.token);
     switch (data.rol) {
       case 'admin':
-        window.location.href = 'dashboard-admin.html';
+        window.location.href = '/dashboard-admin';
         break;
       case 'abogado':
-        window.location.href = 'dashboard-abogado.html';
+        window.location.href = '/dashboard-abogado';
         break;
       default:
-        window.location.href = 'index.html';
+        window.location.href = '/';
     }
   } catch (err) {
     message.textContent = err.message;

--- a/assets/js/politica_seguridad.js
+++ b/assets/js/politica_seguridad.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (inicioLink) {
     inicioLink.addEventListener('click', (event) => {
       event.preventDefault();
-      window.location.href = 'index.html#home';
+      window.location.href = '/#home';
     });
   }
 
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (nosotrosLink) {
     nosotrosLink.addEventListener('click', (event) => {
       event.preventDefault();
-      window.location.href = 'index.html#about';
+      window.location.href = '/#about';
     });
   }
 
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (serviciosLink) {
     serviciosLink.addEventListener('click', (event) => {
       event.preventDefault();
-      window.location.href = 'index.html#services';
+      window.location.href = '/#services';
     });
   }
 
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (correoLink) {
     correoLink.addEventListener('click', (event) => {
       event.preventDefault();
-      window.location.href = 'formulario-contacto.html';
+      window.location.href = '/formulario-contacto';
     });
   }
 
@@ -35,7 +35,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (loginBtn) {
     loginBtn.addEventListener('click', (event) => {
       event.preventDefault();
-      window.location.href = 'login.html';
+      window.location.href = '/login';
     });
   }
 });

--- a/assets/js/scriptPS.js
+++ b/assets/js/scriptPS.js
@@ -1,4 +1,4 @@
 // Añadir evento de clic al botón de inicio
 document.getElementById("menu_inicio").addEventListener("click", function () {
-  window.location.href = "index.html";
+  window.location.href = "/";
 });

--- a/assets/js/styles_VE.js
+++ b/assets/js/styles_VE.js
@@ -35,7 +35,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if (menuPoliticaSeguridad) {
     menuPoliticaSeguridad.addEventListener("click", (event) => {
       event.preventDefault();
-      window.location.href = "politica_seguridad.html";
+      window.location.href = "/politica_seguridad";
     });
   }
 
@@ -43,7 +43,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if (loginBtn) {
     loginBtn.addEventListener("click", (event) => {
       event.preventDefault();
-      window.location.href = "login.html";
+      window.location.href = "/login";
     });
   }
 
@@ -51,7 +51,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if (linkCorreo) {
     linkCorreo.addEventListener("click", (event) => {
       event.preventDefault();
-      window.location.href = "formulario-contacto.html";
+      window.location.href = "/formulario-contacto";
     });
   }
 

--- a/dashboard-admin.html
+++ b/dashboard-admin.html
@@ -573,7 +573,7 @@
     <script>
         function logout() {
             localStorage.removeItem("usuario");
-            window.location.href = "login.html";
+            window.location.href = "/login";
         }
     </script>
 </body>

--- a/formulario-contacto.html
+++ b/formulario-contacto.html
@@ -10,9 +10,9 @@
     <!-- Menú de navegación -->
     <nav>
         <ul>
-            <li><a href="index.html#home"><i class="fas fa-home"></i> Inicio</a></li>
-            <li><a href="index.html#about"><i class="fas fa-users"></i> Nosotros</a></li>
-            <li><a href="index.html#services"><i class="fas fa-briefcase"></i> Servicios</a></li>
+            <li><a href="/#home"><i class="fas fa-home"></i> Inicio</a></li>
+            <li><a href="/#about"><i class="fas fa-users"></i> Nosotros</a></li>
+            <li><a href="/#services"><i class="fas fa-briefcase"></i> Servicios</a></li>
             <li><a href="#" id="menu_politica_seguridad"><i class="fas fa-shield-alt"></i> Seguridad y Privacidad</a></li>
         </ul>
     </nav>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
             <li><a href="#home">Inicio</a></li>
             <li><a href="#about">Nosotros</a></li>
             <li><a href="#services">Servicios</a></li>
-            <li><a href="politica_seguridad.html" id="menu_politica_seguridad">Seguridad</a></li>
+            <li><a href="/politica_seguridad" id="menu_politica_seguridad">Seguridad</a></li>
             <li class="submenu">
               <a href="#">Contacto</a>
               <ul class="submenu-options">

--- a/login.html
+++ b/login.html
@@ -20,7 +20,7 @@
       <input type="password" id="pass" required>
       <button type="submit">Ingresar</button>
       <div id="message" class="mt-2 text-danger"></div>
-      <a href="index.html" class="back-btn"><i class="fas fa-arrow-left"></i> Volver al inicio</a>
+      <a href="/" class="back-btn"><i class="fas fa-arrow-left"></i> Volver al inicio</a>
     </form>
   </div>
 


### PR DESCRIPTION
## Summary
- Drop `.html` from site navigation so routes like `/politica_seguridad` and `/#services` are extensionless
- Redirect buttons and scripts to the new extensionless paths

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b99bcfd988326b5086cb82a25751e