### PR TITLE
chore: update nedb dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "type": "commonjs",
   "dependencies": {
     "express": "^4.18.2",
-    "@seald-io/nedb": "^1.8.0"
+    "@seald-io/nedb": "^2.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- update @seald-io/nedb to ^2.2.0

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@seald-io%2fbinary-search-tree)*
- `npm test`
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_689cae80e9ec8326b5a6f0f1dd3fa342