### PR TITLE
feat: add user registration to login

### DIFF
--- a/assets/css/loginStyles.css
+++ b/assets/css/loginStyles.css
@@ -65,3 +65,16 @@ body {
 .back-btn:hover {
   color: #d4af37;
 }
+
+.toggle-link {
+  display: block;
+  text-align: center;
+  margin-top: 1rem;
+  color: #1a1a1a;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.toggle-link:hover {
+  color: #d4af37;
+}

--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -29,10 +29,39 @@ async function login(event) {
   }
 }
 
+async function register(event) {
+  event.preventDefault();
+  const usuario = document.getElementById('newUser').value.trim();
+  const password = document.getElementById('newPass').value.trim();
+  const message = document.getElementById('registerMessage');
+  message.textContent = '';
+  message.classList.remove('text-danger', 'text-success');
+
+  try {
+    const res = await fetch('/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ usuario, password })
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.message || 'Error en el servidor');
+    message.classList.add('text-success');
+    message.textContent = 'Registro exitoso. Ya puedes iniciar sesión.';
+    document.getElementById('registerForm').reset();
+  } catch (err) {
+    message.classList.add('text-danger');
+    message.textContent = err.message;
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('loginForm');
   if (form) {
     form.addEventListener('submit', login);
+  }
+  const registerForm = document.getElementById('registerForm');
+  if (registerForm) {
+    registerForm.addEventListener('submit', register);
   }
 });
 

--- a/login.html
+++ b/login.html
@@ -20,10 +20,22 @@
       <input type="password" id="pass" required>
       <button type="submit">Ingresar</button>
       <div id="message" class="mt-2 text-danger"></div>
-      <a href="/" class="back-btn"><i class="fas fa-arrow-left"></i> Volver al inicio</a>
     </form>
+    <a class="toggle-link" data-bs-toggle="collapse" href="#registerCollapse" role="button" aria-expanded="false" aria-controls="registerCollapse">¿No tienes cuenta? Regístrate</a>
+    <div class="collapse mt-3" id="registerCollapse">
+      <form id="registerForm">
+        <label>Usuario:</label>
+        <input type="text" id="newUser" required>
+        <label>Contraseña:</label>
+        <input type="password" id="newPass" required>
+        <button type="submit">Registrar</button>
+        <div id="registerMessage" class="mt-2"></div>
+      </form>
+    </div>
+    <a href="/" class="back-btn"><i class="fas fa-arrow-left"></i> Volver al inicio</a>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="assets/js/login.js"></script>
 
 </body>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "type": "commonjs",
   "dependencies": {
     "express": "^4.18.2",
-    "@seald-io/nedb": "^1.8.0"
+    "@seald-io/nedb": "^2.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- update @seald-io/nedb to ^2.2.0
- add collapsible registration form to the login page with Bootstrap animation

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@seald-io%2fbinary-search-tree)*
- `npm test`
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_689cae80e9ec8326b5a6f0f1dd3fa342