### PR TITLE
feat: enhance login and session handling

### DIFF
--- a/assets/css/loginStyles.css
+++ b/assets/css/loginStyles.css
@@ -65,3 +65,16 @@ body {
 .back-btn:hover {
   color: #d4af37;
 }
+
+.toggle-link {
+  display: block;
+  text-align: center;
+  margin-top: 1rem;
+  color: #1a1a1a;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.toggle-link:hover {
+  color: #d4af37;
+}

--- a/assets/css/newNewStyles.css
+++ b/assets/css/newNewStyles.css
@@ -33,6 +33,7 @@ body {
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 1rem;
+  position: relative;
 }
 
 .logo {
@@ -147,6 +148,29 @@ body {
 .login-btn:hover {
   background-color: #d4af37;
   color: #000;
+}
+
+.user-icon {
+  color: #d4af37;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.user-info {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background-color: #fff;
+  color: #000;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+  white-space: nowrap;
+}
+
+.user-info.show {
+  display: block;
 }
 
 

--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -29,10 +29,53 @@ async function login(event) {
   }
 }
 
+async function register(event) {
+  event.preventDefault();
+  const usuario = document.getElementById('newUser').value.trim();
+  const password = document.getElementById('newPass').value.trim();
+  const message = document.getElementById('registerMessage');
+  message.textContent = '';
+  message.classList.remove('text-danger', 'text-success');
+
+  try {
+    const res = await fetch('/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ usuario, password })
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.message || 'Error en el servidor');
+    message.classList.add('text-success');
+    message.textContent = 'Registro exitoso. Ya puedes iniciar sesión.';
+    document.getElementById('registerForm').reset();
+    const collapse = bootstrap.Collapse.getInstance(document.getElementById('registerCollapse'));
+    if (collapse) collapse.hide();
+  } catch (err) {
+    message.classList.add('text-danger');
+    message.textContent = err.message;
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('loginForm');
+  const registerForm = document.getElementById('registerForm');
+  const registerCollapse = document.getElementById('registerCollapse');
+  const loginTitle = document.querySelector('.login-container h2');
   if (form) {
     form.addEventListener('submit', login);
+  }
+  if (registerForm) {
+    registerForm.addEventListener('submit', register);
+  }
+  if (registerCollapse && form) {
+    registerCollapse.addEventListener('show.bs.collapse', () => {
+      form.style.display = 'none';
+      if (loginTitle) loginTitle.style.display = 'none';
+    });
+    registerCollapse.addEventListener('hide.bs.collapse', () => {
+      form.style.display = 'block';
+      if (loginTitle) loginTitle.style.display = 'block';
+    });
   }
 });
 

--- a/assets/js/styles_VE.js
+++ b/assets/js/styles_VE.js
@@ -1,6 +1,16 @@
 // Archivo: styles_VE.js
 
-document.addEventListener("DOMContentLoaded", () => {
+async function verificarSesion() {
+  const token = localStorage.getItem('token');
+  if (!token) return null;
+  try {
+    const res = await fetch('/api/verify', { headers: { 'Authorization': 'Bearer ' + token } });
+    if (res.ok) return res.json();
+  } catch (e) {}
+  return null;
+}
+
+document.addEventListener("DOMContentLoaded", async () => {
   const aboutItems = document.querySelectorAll(".about-item");
   const modales = document.querySelectorAll(".about-item");
 
@@ -40,10 +50,21 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   const loginBtn = document.getElementById("login_btn");
-  if (loginBtn) {
-    loginBtn.addEventListener("click", (event) => {
+  const userInfoDiv = document.getElementById('userInfo');
+  const session = await verificarSesion();
+  if (session && loginBtn && userInfoDiv) {
+    loginBtn.innerHTML = '<i class="fas fa-user"></i>';
+    loginBtn.classList.remove('btn', 'btn-outline-light', 'login-btn');
+    loginBtn.classList.add('user-icon');
+    userInfoDiv.textContent = `Usuario: ${session.usuario} (${session.rol})`;
+    loginBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      userInfoDiv.classList.toggle('show');
+    });
+  } else if (loginBtn) {
+    loginBtn.addEventListener('click', (event) => {
       event.preventDefault();
-      window.location.href = "/login";
+      window.location.href = '/login';
     });
   }
 

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
           <button id="search-btn"><i class="fas fa-search"></i></button>
         </div>
         <a href="#" class="btn btn-outline-light login-btn" id="login_btn">Iniciar sesión</a>
+        <div id="userInfo" class="user-info"></div>
       </div>
 
 

--- a/login.html
+++ b/login.html
@@ -20,10 +20,22 @@
       <input type="password" id="pass" required>
       <button type="submit">Ingresar</button>
       <div id="message" class="mt-2 text-danger"></div>
-      <a href="/" class="back-btn"><i class="fas fa-arrow-left"></i> Volver al inicio</a>
     </form>
+    <a class="toggle-link" data-bs-toggle="collapse" href="#registerCollapse" role="button" aria-expanded="false" aria-controls="registerCollapse">¿No tienes cuenta? Regístrate</a>
+    <div class="collapse mt-3" id="registerCollapse">
+      <form id="registerForm">
+        <label>Usuario:</label>
+        <input type="text" id="newUser" required>
+        <label>Contraseña:</label>
+        <input type="password" id="newPass" required>
+        <button type="submit">Registrar</button>
+        <div id="registerMessage" class="mt-2"></div>
+      </form>
+    </div>
+    <a href="/" class="back-btn"><i class="fas fa-arrow-left"></i> Volver al inicio</a>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="assets/js/login.js"></script>
 
 </body>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "type": "commonjs",
   "dependencies": {
     "express": "^4.18.2",
-    "@seald-io/nedb": "^1.8.0"
+    "@seald-io/nedb": "^2.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- hide login form when expanding registration and collapse registration after signup
- replace login button with user icon when session exists and show user details on click

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@seald-io%2fbinary-search-tree)*
- `npm test`
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_689cae80e9ec8326b5a6f0f1dd3fa342