### PR TITLE
Eliminar selección de roles al registrarse

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ Una vez iniciado, abre [http://localhost:3000](http://localhost:3000) en tu nave
 ## Detalles
 
 El servidor se ejecuta por defecto en el puerto `3000`. Puedes cambiarlo estableciendo la variable de entorno `PORT` antes de iniciar la aplicación.
+
+### Registro de usuarios
+
+Los nuevos usuarios se crean siempre con el rol `cliente`; no es posible seleccionar un rol diferente durante el registro.

--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -33,7 +33,6 @@ async function login(event) {
     event.preventDefault();
     const usuario = document.getElementById('newUser').value.trim();
     const password = document.getElementById('newPass').value.trim();
-    const rol = document.getElementById('newRole').value;
     const message = document.getElementById('registerMessage');
     message.textContent = '';
     message.classList.remove('text-danger', 'text-success');
@@ -42,7 +41,7 @@ async function login(event) {
       const res = await fetch('/api/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ usuario, password, rol })
+        body: JSON.stringify({ usuario, password })
       });
 
     const data = await res.json();

--- a/login.html
+++ b/login.html
@@ -28,12 +28,6 @@
         <input type="text" id="newUser" required>
         <label>Contraseña:</label>
         <input type="password" id="newPass" required>
-        <label>Rol:</label>
-        <select id="newRole">
-          <option value="cliente" selected>Cliente</option>
-          <option value="abogado">Abogado</option>
-          <option value="admin">Administrador</option>
-        </select>
 
         <button type="submit">Registrar</button>
         <div id="registerMessage" class="mt-2"></div>

--- a/server.js
+++ b/server.js
@@ -20,7 +20,7 @@ function createToken() {
 }
 
 app.post('/api/register', (req, res) => {
-  const { usuario, password, rol } = req.body;
+  const { usuario, password } = req.body;
   if (!usuario || !password) {
     return res.status(400).json({ message: 'Usuario y contraseña requeridos' });
   }
@@ -32,7 +32,7 @@ app.post('/api/register', (req, res) => {
       return res.status(409).json({ message: 'Usuario ya existe' });
     }
     const hashed = bcrypt.hash(password);
-    db.insert({ usuario, password: hashed, rol: rol || 'cliente' }, (err) => {
+    db.insert({ usuario, password: hashed, rol: 'cliente' }, (err) => {
       if (err) {
         return res.status(500).json({ message: 'Error en el servidor' });
       }


### PR DESCRIPTION
## Resumen
- Elimina el campo de selección de rol del formulario de registro y su uso en el frontend.
- Ajusta la API de registro para ignorar `req.body.rol` y asignar siempre el rol `cliente`.
- Documenta que el registro crea usuarios con rol `cliente` por defecto.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cbd19f64c83269f82e45abe673b39