### PR TITLE
feat: add role management endpoint and dashboard

### DIFF
--- a/assets/js/abogado.js
+++ b/assets/js/abogado.js
@@ -1,12 +1,7 @@
 function cerrarSesion() {
-  localStorage.removeItem("usuario");
-  window.location.href = "/";
-}
-
-const usuario = JSON.parse(localStorage.getItem("usuario"));
-if (!usuario || usuario.rol !== "abogado") {
-  alert("Acceso no autorizado");
-  window.location.href = "/login";
+  localStorage.removeItem('token');
+  document.cookie = 'token=; Max-Age=0; Path=/';
+  window.location.href = '/login';
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/assets/js/acceso.js
+++ b/assets/js/acceso.js
@@ -1,5 +1,22 @@
-const usuario = JSON.parse(localStorage.getItem("usuario"));
-if (!usuario) {
-  alert("Debes iniciar sesión para acceder a esta sección.");
-  window.location.href = "/login";
-}
+(async () => {
+  const token = localStorage.getItem('token');
+  if (!token) {
+    alert('Debes iniciar sesión para acceder a esta sección.');
+    window.location.href = '/login';
+    return;
+  }
+  try {
+    const res = await fetch('/api/verify', { headers: { 'Authorization': 'Bearer ' + token } });
+    const data = await res.json();
+    if (!res.ok) throw new Error();
+    const path = window.location.pathname;
+    if ((path.includes('dashboard-admin') && data.rol !== 'admin') ||
+        (path.includes('dashboard-abogado') && data.rol !== 'abogado')) {
+      throw new Error();
+    }
+  } catch (err) {
+    alert('Acceso no autorizado');
+    window.location.href = '/login';
+  }
+})();
+

--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -14,6 +14,7 @@ async function login(event) {
     const data = await res.json();
     if (!res.ok) throw new Error(data.message || 'Error en el servidor');
     localStorage.setItem('token', data.token);
+    document.cookie = `token=${data.token}; Path=/`;
     switch (data.rol) {
       case 'admin':
         window.location.href = '/dashboard-admin';

--- a/dashboard-admin.html
+++ b/dashboard-admin.html
@@ -149,47 +149,11 @@
                             <tr>
                                 <th>ID</th>
                                 <th>Nombre</th>
-                                <th>Email</th>
                                 <th>Rol</th>
-                                <th>Estado</th>
                                 <th>Acciones</th>
                             </tr>
                         </thead>
-                        <tbody>
-                            <tr>
-                                <td>1</td>
-                                <td>Admin Principal</td>
-                                <td>admin@despacholegal.com</td>
-                                <td><span class="badge badge-admin">Administrador</span></td>
-                                <td><span class="badge badge-active">Activo</span></td>
-                                <td>
-                                    <button class="btn-icon btn-edit"><i class="fas fa-edit"></i></button>
-                                    <button class="btn-icon btn-delete"><i class="fas fa-trash"></i></button>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>2</td>
-                                <td>María Gómez</td>
-                                <td>maria.gomez@despacholegal.com</td>
-                                <td><span class="badge badge-lawyer">Abogado</span></td>
-                                <td><span class="badge badge-active">Activo</span></td>
-                                <td>
-                                    <button class="btn-icon btn-edit"><i class="fas fa-edit"></i></button>
-                                    <button class="btn-icon btn-delete"><i class="fas fa-trash"></i></button>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>3</td>
-                                <td>Carlos Ruiz</td>
-                                <td>carlos.ruiz@despacholegal.com</td>
-                                <td><span class="badge badge-lawyer">Abogado</span></td>
-                                <td><span class="badge badge-inactive">Inactivo</span></td>
-                                <td>
-                                    <button class="btn-icon btn-edit"><i class="fas fa-edit"></i></button>
-                                    <button class="btn-icon btn-delete"><i class="fas fa-trash"></i></button>
-                                </td>
-                            </tr>
-                        </tbody>
+                        <tbody id="users-body"></tbody>
                     </table>
                 </div>
                 
@@ -571,9 +535,46 @@
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
+        const token = localStorage.getItem('token');
+        async function loadUsers() {
+            const res = await fetch('/api/users', { headers: { 'Authorization': 'Bearer ' + token } });
+            if (!res.ok) return;
+            const users = await res.json();
+            const tbody = document.getElementById('users-body');
+            tbody.innerHTML = '';
+            users.forEach(u => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>${u._id}</td>
+                    <td>${u.usuario}</td>
+                    <td>
+                        <select data-id="${u._id}">
+                            <option value="admin"${u.rol === 'admin' ? ' selected' : ''}>admin</option>
+                            <option value="abogado"${u.rol === 'abogado' ? ' selected' : ''}>abogado</option>
+                            <option value="cliente"${u.rol === 'cliente' ? ' selected' : ''}>cliente</option>
+                        </select>
+                        <button class="btn-icon btn-edit" data-id="${u._id}"><i class="fas fa-save"></i></button>
+                    </td>`;
+                const select = tr.querySelector('select');
+                tr.querySelector('button').addEventListener('click', async () => {
+                    const rol = select.value;
+                    await fetch(`/api/users/${u._id}/role`, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'Authorization': 'Bearer ' + token
+                        },
+                        body: JSON.stringify({ rol })
+                    });
+                });
+                tbody.appendChild(tr);
+            });
+        }
+        document.addEventListener('DOMContentLoaded', loadUsers);
         function logout() {
-            localStorage.removeItem("usuario");
-            window.location.href = "/login";
+            localStorage.removeItem('token');
+            document.cookie = 'token=; Max-Age=0; Path=/';
+            window.location.href = '/login';
         }
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add admin protected endpoints to list users and change roles
- secure admin and lawyer dashboards by validating tokens server-side
- enable admin dashboard to manage user roles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cdcf0f83483269747ca23bcbe2746