### PR TITLE
feat: add super admin role and improve user management

### DIFF
--- a/assets/js/abogado.js
+++ b/assets/js/abogado.js
@@ -1,12 +1,7 @@
 function cerrarSesion() {
-  localStorage.removeItem("usuario");
-  window.location.href = "/";
-}
-
-const usuario = JSON.parse(localStorage.getItem("usuario"));
-if (!usuario || usuario.rol !== "abogado") {
-  alert("Acceso no autorizado");
-  window.location.href = "/login";
+  localStorage.removeItem('token');
+  document.cookie = 'token=; Max-Age=0; Path=/';
+  window.location.href = '/login';
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/assets/js/acceso.js
+++ b/assets/js/acceso.js
@@ -1,5 +1,22 @@
-const usuario = JSON.parse(localStorage.getItem("usuario"));
-if (!usuario) {
-  alert("Debes iniciar sesión para acceder a esta sección.");
-  window.location.href = "/login";
-}
+(async () => {
+  const token = localStorage.getItem('token');
+  if (!token) {
+    alert('Debes iniciar sesión para acceder a esta sección.');
+    window.location.href = '/login';
+    return;
+  }
+  try {
+    const res = await fetch('/api/verify', { headers: { 'Authorization': 'Bearer ' + token } });
+    const data = await res.json();
+    if (!res.ok) throw new Error();
+    const path = window.location.pathname;
+    if ((path.includes('dashboard-admin') && !['admin','super_admin'].includes(data.rol)) ||
+        (path.includes('dashboard-abogado') && data.rol !== 'abogado')) {
+      throw new Error();
+    }
+  } catch (err) {
+    alert('Acceso no autorizado');
+    window.location.href = '/login';
+  }
+})();
+

--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -14,7 +14,9 @@ async function login(event) {
     const data = await res.json();
     if (!res.ok) throw new Error(data.message || 'Error en el servidor');
     localStorage.setItem('token', data.token);
+    document.cookie = `token=${data.token}; Path=/`;
     switch (data.rol) {
+      case 'super_admin':
       case 'admin':
         window.location.href = '/dashboard-admin';
         break;

--- a/dashboard-admin.html
+++ b/dashboard-admin.html
@@ -148,48 +148,12 @@
                         <thead>
                             <tr>
                                 <th>ID</th>
-                                <th>Nombre</th>
-                                <th>Email</th>
+                                <th>Usuario</th>
                                 <th>Rol</th>
-                                <th>Estado</th>
                                 <th>Acciones</th>
                             </tr>
                         </thead>
-                        <tbody>
-                            <tr>
-                                <td>1</td>
-                                <td>Admin Principal</td>
-                                <td>admin@despacholegal.com</td>
-                                <td><span class="badge badge-admin">Administrador</span></td>
-                                <td><span class="badge badge-active">Activo</span></td>
-                                <td>
-                                    <button class="btn-icon btn-edit"><i class="fas fa-edit"></i></button>
-                                    <button class="btn-icon btn-delete"><i class="fas fa-trash"></i></button>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>2</td>
-                                <td>María Gómez</td>
-                                <td>maria.gomez@despacholegal.com</td>
-                                <td><span class="badge badge-lawyer">Abogado</span></td>
-                                <td><span class="badge badge-active">Activo</span></td>
-                                <td>
-                                    <button class="btn-icon btn-edit"><i class="fas fa-edit"></i></button>
-                                    <button class="btn-icon btn-delete"><i class="fas fa-trash"></i></button>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>3</td>
-                                <td>Carlos Ruiz</td>
-                                <td>carlos.ruiz@despacholegal.com</td>
-                                <td><span class="badge badge-lawyer">Abogado</span></td>
-                                <td><span class="badge badge-inactive">Inactivo</span></td>
-                                <td>
-                                    <button class="btn-icon btn-edit"><i class="fas fa-edit"></i></button>
-                                    <button class="btn-icon btn-delete"><i class="fas fa-trash"></i></button>
-                                </td>
-                            </tr>
-                        </tbody>
+                        <tbody id="users-body"></tbody>
                     </table>
                 </div>
                 
@@ -200,20 +164,17 @@
                         <h3>Agregar Nuevo Usuario</h3>
                         <form id="add-user-form">
                             <div class="form-group">
-                                <label for="user-name">Nombre Completo</label>
-                                <input type="text" id="user-name" required>
-                            </div>
-                            <div class="form-group">
-                                <label for="user-email">Email</label>
-                                <input type="email" id="user-email" required>
+                                <label for="user-username">Usuario</label>
+                                <input type="text" id="user-username" required>
                             </div>
                             <div class="form-group">
                                 <label for="user-role">Rol</label>
                                 <select id="user-role" required>
                                     <option value="">Seleccionar rol...</option>
-                                    <option value="admin">Administrador</option>
-                                    <option value="lawyer">Abogado</option>
-                                    <option value="assistant">Asistente</option>
+                                    <option value="super_admin">Super Admin</option>
+                                    <option value="admin">Admin</option>
+                                    <option value="abogado">Abogado</option>
+                                    <option value="cliente">Cliente</option>
                                 </select>
                             </div>
                             <div class="form-group">
@@ -571,9 +532,125 @@
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
+        const token = localStorage.getItem('token');
+        let currentRole = null;
+
+        async function fetchSession() {
+            const res = await fetch('/api/verify', { headers: { 'Authorization': 'Bearer ' + token } });
+            if (res.ok) {
+                const data = await res.json();
+                currentRole = data.rol;
+            }
+        }
+
+        async function loadUsers() {
+            const res = await fetch('/api/users', { headers: { 'Authorization': 'Bearer ' + token } });
+            if (!res.ok) return;
+            const users = await res.json();
+            const tbody = document.getElementById('users-body');
+            tbody.innerHTML = '';
+            users.forEach(u => {
+                const tr = document.createElement('tr');
+                const roleOptions = [];
+                const roles = currentRole === 'super_admin' ? ['super_admin','admin','abogado','cliente'] : ['abogado','cliente'];
+                if (!roles.includes(u.rol)) roles.push(u.rol);
+                roles.forEach(r => {
+                    roleOptions.push(`<option value="${r}"${u.rol === r ? ' selected' : ''}>${r}</option>`);
+                });
+                tr.innerHTML = `
+                    <td>${u._id}</td>
+                    <td>${u.usuario}</td>
+                    <td>
+                        <select data-id="${u._id}">${roleOptions.join('')}</select>
+                        <button class="btn-icon btn-edit" data-id="${u._id}"><i class="fas fa-save"></i></button>
+                    </td>`;
+                const select = tr.querySelector('select');
+                const btn = tr.querySelector('button');
+                if (currentRole === 'admin' && (u.rol === 'admin' || u.rol === 'super_admin')) {
+                    select.disabled = true;
+                    btn.disabled = true;
+                }
+                btn.addEventListener('click', async () => {
+                    const rol = select.value;
+                    await fetch(`/api/users/${u._id}/role`, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'Authorization': 'Bearer ' + token
+                        },
+                        body: JSON.stringify({ rol })
+                    });
+                    loadUsers();
+                });
+                tbody.appendChild(tr);
+            });
+        }
+
+        function setupAddUserModal() {
+            const modal = document.getElementById('add-user-modal');
+            const openBtn = document.getElementById('add-user-btn');
+            const closeBtns = modal.querySelectorAll('.close-modal');
+
+            openBtn.addEventListener('click', () => modal.style.display = 'block');
+            closeBtns.forEach(btn => btn.addEventListener('click', () => modal.style.display = 'none'));
+            window.addEventListener('click', (e) => { if (e.target === modal) modal.style.display = 'none'; });
+
+            document.getElementById('add-user-form').addEventListener('submit', async (e) => {
+                e.preventDefault();
+                const usuario = document.getElementById('user-username').value.trim();
+                const password = document.getElementById('user-password').value.trim();
+                const rol = document.getElementById('user-role').value;
+                const res = await fetch('/api/users', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': 'Bearer ' + token
+                    },
+                    body: JSON.stringify({ usuario, password, rol })
+                });
+                const data = await res.json();
+                if (res.ok) {
+                    modal.style.display = 'none';
+                    e.target.reset();
+                    loadUsers();
+                } else {
+                    alert(data.message || 'Error');
+                }
+            });
+        }
+
+        function setupNavigation() {
+            const links = document.querySelectorAll('.admin-menu a');
+            const sections = document.querySelectorAll('.content-section');
+            const sectionTitle = document.getElementById('section-title');
+
+            links.forEach(link => {
+                link.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    const target = link.getAttribute('href').substring(1);
+                    sections.forEach(sec => sec.classList.remove('active'));
+                    document.getElementById(target).classList.add('active');
+                    sectionTitle.textContent = link.textContent.trim();
+                    document.querySelectorAll('.admin-menu li').forEach(li => li.classList.remove('active'));
+                    link.parentElement.classList.add('active');
+                    if (target === 'usuarios') {
+                        loadUsers();
+                    }
+                });
+            });
+        }
+
+        document.addEventListener('DOMContentLoaded', async () => {
+            await fetchSession();
+            setupNavigation();
+            setupAddUserModal();
+            loadUsers();
+        });
+
         function logout() {
-            localStorage.removeItem("usuario");
-            window.location.href = "/login";
+            localStorage.removeItem('token');
+            document.cookie = 'token=; Max-Age=0; Path=/';
+            window.location.href = '/login';
         }
     </script>
 </body>

--- a/server.js
+++ b/server.js
@@ -12,11 +12,34 @@ app.use(express.static(__dirname));
 const dbFile = path.join(__dirname, 'data', 'users.db');
 fs.mkdirSync(path.dirname(dbFile), { recursive: true });
 const db = new Datastore({ filename: dbFile, autoload: true });
+db.ensureIndex({ fieldName: 'usuario', unique: true });
 
 const sessions = {}; // token -> {usuario, rol, exp}
 
 function createToken() {
   return crypto.randomBytes(30).toString('hex');
+}
+
+function getToken(req) {
+  const auth = req.headers['authorization'] || '';
+  if (auth.startsWith('Bearer ')) {
+    return auth.split(' ')[1];
+  }
+  const cookies = req.headers.cookie || '';
+  const match = cookies.match(/token=([^;]+)/);
+  return match ? match[1] : null;
+}
+
+function requireRole(...roles) {
+  return (req, res, next) => {
+    const token = getToken(req);
+    const session = token && sessions[token];
+    if (session && session.exp > Date.now() && roles.includes(session.rol)) {
+      req.session = session;
+      return next();
+    }
+    return res.status(401).json({ message: 'No autorizado' });
+  };
 }
 
 app.post('/api/register', (req, res) => {
@@ -63,6 +86,76 @@ app.get('/api/verify', (req, res) => {
     return res.status(200).json({ usuario: sessions[token].usuario, rol: sessions[token].rol });
   }
   return res.status(401).json({ message: 'Token inválido' });
+});
+
+app.get('/api/users', requireRole('admin', 'super_admin'), (req, res) => {
+  db.find({}, { password: 0 }, (err, users) => {
+    if (err) {
+      return res.status(500).json({ message: 'Error en el servidor' });
+    }
+    return res.status(200).json(users);
+  });
+});
+
+app.post('/api/users', requireRole('admin', 'super_admin'), (req, res) => {
+  const { usuario, password, rol } = req.body;
+  const allowed = ['super_admin', 'admin', 'abogado', 'cliente'];
+  if (!usuario || !password || !allowed.includes(rol)) {
+    return res.status(400).json({ message: 'Datos inválidos' });
+  }
+  if (req.session.rol === 'admin' && (rol === 'admin' || rol === 'super_admin')) {
+    return res.status(403).json({ message: 'No autorizado' });
+  }
+  const hashed = bcrypt.hash(password);
+  db.insert({ usuario, password: hashed, rol }, (err) => {
+    if (err) {
+      if (err.errorType === 'uniqueViolated') {
+        return res.status(409).json({ message: 'Usuario ya existe' });
+      }
+      return res.status(500).json({ message: 'Error en el servidor' });
+    }
+    return res.status(201).json({ message: 'Usuario creado' });
+  });
+});
+
+app.post('/api/users/:id/role', requireRole('admin', 'super_admin'), (req, res) => {
+  const { id } = req.params;
+  const { rol } = req.body;
+  const allowed = ['super_admin', 'admin', 'abogado', 'cliente'];
+  if (!allowed.includes(rol)) {
+    return res.status(400).json({ message: 'Rol inválido' });
+  }
+  db.findOne({ _id: id }, (err, user) => {
+    if (err) {
+      return res.status(500).json({ message: 'Error en el servidor' });
+    }
+    if (!user) {
+      return res.status(404).json({ message: 'Usuario no encontrado' });
+    }
+    const requester = req.session.rol;
+    if (requester === 'admin') {
+      if (user.rol === 'admin' || user.rol === 'super_admin' || rol === 'admin' || rol === 'super_admin') {
+        return res.status(403).json({ message: 'No autorizado' });
+      }
+    }
+    db.update({ _id: id }, { $set: { rol } }, {}, (err, num) => {
+      if (err) {
+        return res.status(500).json({ message: 'Error en el servidor' });
+      }
+      if (num === 0) {
+        return res.status(404).json({ message: 'Usuario no encontrado' });
+      }
+      return res.status(200).json({ message: 'Rol actualizado' });
+    });
+  });
+});
+
+app.get('/dashboard-admin', requireRole('admin', 'super_admin'), (req, res) => {
+  return res.sendFile(path.join(__dirname, 'dashboard-admin.html'));
+});
+
+app.get('/dashboard-abogado', requireRole('abogado'), (req, res) => {
+  return res.sendFile(path.join(__dirname, 'dashboard-abogado.html'));
 });
 
 app.get('/', (req, res) => {


### PR DESCRIPTION
## Summary
- introduce `super_admin` role, unique user index, and admin-only endpoints for creating and updating users
- enable admin dashboard to add users and restrict role edits so only super admins can modify admins
- recognize super admins during login and access checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cdcf0f83483269747ca23bcbe2746