### PR TITLE
Add dotenv support for database configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ Los nuevos usuarios se crean siempre con el rol `cliente`; no es posible selecci
 Esta versión utiliza **PostgreSQL** para almacenar los usuarios. Para que el servidor funcione necesitas:
 
 1. Tener una instancia de PostgreSQL accesible.
-2. Definir la variable de entorno `DATABASE_URL` con la cadena de conexión completa  
-   (por ejemplo: `postgres://usuario:password@host:5432/mi_base`).
+2. Definir la variable de entorno `DATABASE_URL` con la cadena de conexión completa
+   (por ejemplo: `export DATABASE_URL="postgres://usuario:password@host:5432/mi_base"`).
+   Si prefieres cargarla desde un archivo local, crea un fichero `.env` con esa clave y
+   el servidor la leerá automáticamente mediante [`dotenv`](https://www.npmjs.com/package/dotenv).
 3. El servidor creará automáticamente la tabla `usuarios` si no existe. El esquema es:
    ```sql
    CREATE TABLE IF NOT EXISTS usuarios (
@@ -42,4 +44,4 @@ Esta versión utiliza **PostgreSQL** para almacenar los usuarios. Para que el se
    );
    ```
 
-En entornos de producción donde el proveedor requiera SSL (como algunos planes gratuitos), deja `NODE_ENV=production` para habilitar una conexión segura.
+Si la base de datos remota requiere SSL (como ocurre en algunos proveedores), la conexión lo habilita automáticamente siempre que `DATABASE_URL` no apunte a `localhost`.

--- a/db.js
+++ b/db.js
@@ -1,8 +1,12 @@
 const { Pool } = require('pg');
 
+const connectionString = process.env.DATABASE_URL;
+
+const useSSL = connectionString && !/localhost|127\.0\.0\.1/.test(connectionString);
+
 const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+  connectionString,
+  ssl: useSSL ? { rejectUnauthorized: false } : false,
 });
 
 module.exports = pool;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "type": "commonjs",
   "dependencies": {
     "express": "^4.18.2",
-    "pg": "^8.16.3"
+    "pg": "^8.16.3",
+    "dotenv": "^16.4.5"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const path = require('path');
 const fs = require('fs');


### PR DESCRIPTION
## Summary
- load environment variables with dotenv before starting the server
- automatically enable SSL for remote PostgreSQL connections unless `DATABASE_URL` points to localhost
- document how to export `DATABASE_URL`, use a `.env` file, and the automatic SSL behavior
- declare `dotenv` dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b20490e6708326a622f9f6e48a774b